### PR TITLE
刪除一個錯誤詞條，添加單字「丅」。

### DIFF
--- a/char.csv
+++ b/char.csv
@@ -10811,6 +10811,7 @@ char,jyutping,fq
 哈,haa5,0%
 下,haa5
 奤,haa5
+丅,haa6,0%
 乤,haa6,0%
 圷,haa6,0%
 夓,haa6,0%

--- a/word.csv
+++ b/word.csv
@@ -38747,7 +38747,6 @@ char,jyutping
 喝酒,hot3 zau2
 喝早茶,hot3 zou2 caa4
 薅草,hou1 cou2
-好！,hou2
 好嘔心,hou2 au2 sam1
 好白淨,hou2 baak6 zeng6
 好弊,hou2 bai6


### PR DESCRIPTION
丅 `U+4E05` 係「下」嘅古字。
Unihan： https://www.unicode.org/cgi-bin/GetUnihanData.pl?codepoint=丅
字統網：https://zi.tools/zi/丅