### PR TITLE
修正「紆尊降貴」讀音

### DIFF
--- a/word.csv
+++ b/word.csv
@@ -64365,7 +64365,7 @@ char,jyutping
 紅鰹,hung4 gin1
 紅鱲,hung4 laap6
 紅黴素,hung4 mei4 sou3
-紆尊降貴,syu1 zyun1 gong3 gwai3
+紆尊降貴,jyu1 zyun1 gong3 gwai3
 紈絝子弟,jyun4 fu3 zi2 dai6
 紉針,jan6 zam1
 紊亂,man5 lyun6


### PR DESCRIPTION
「紆」應為jyu1