### PR TITLE
修正「作繭自縛」讀音

### DIFF
--- a/word.csv
+++ b/word.csv
@@ -5784,7 +5784,7 @@ char,jyutping
 作筆記,zok3 bat1 gei3
 作答,zok3 daap3
 作繭,zok3 gaan2
-作繭自縛,zok3 gaan2 zi6 bong2
+作繭自縛,zok3 gaan2 zi6 bok3
 作置,zok3 zi3
 作罷,zok3 baa6
 作者,zok3 ze2


### PR DESCRIPTION
「縛」應為bok3